### PR TITLE
feat: Add ExtendFS to take one FS and make a new one from it

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -30,8 +30,8 @@ func New() *FS {
 	}
 }
 
-// ExtendFS allows you to take on fs.FS and wrap it in an fs that is writable
-func ExtendFS(base fs.FS) *FS {
+// CloneFS allows you to take on fs.FS and wrap it in an fs that is writable
+func CloneFS(base fs.FS) *FS {
 	newFS := New()
 	fs.WalkDir(base, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/fs_test.go
+++ b/fs_test.go
@@ -270,17 +270,17 @@ func Test_WriteWhileOpen(t *testing.T) {
 	assert.Equal(t, "hello world", string(data))
 }
 
-func Test_ExtendFS(t *testing.T) {
+func Test_CloneFS(t *testing.T) {
 	memfs := New()
 	require.NoError(t, memfs.WriteFile("file1.txt", []byte("This is the first file"), fs.ModePerm))
 	require.NoError(t, memfs.MkdirAll("/original/fs", fs.ModeDir))
 	require.NoError(t, memfs.WriteFile("original/fs/nested.txt", []byte("This is the nested file"), fs.ModePerm))
 
-	extended := ExtendFS(memfs)
-	require.NoError(t, extended.WriteFile("second.txt", []byte("This is the second file"), fs.ModePerm))
+	clone := CloneFS(memfs)
+	require.NoError(t, clone.WriteFile("second.txt", []byte("This is the second file"), fs.ModePerm))
 
 	for _, filename := range []string{"file1.txt", "/original/fs/nested.txt", "second.txt"} {
-		f, err := extended.Open(filename)
+		f, err := clone.Open(filename)
 		require.NoError(t, err)
 		defer func() { _ = f.Close() }()
 


### PR DESCRIPTION
This is particularly dandy in situations when you have something that
implements fs.FS but you can't write to it and you want a memoryfs.FS to
work with and add stuff too.

Signed-off-by: Owen Rumney <owen@owenrumney.co.uk>
